### PR TITLE
macOS Sierra compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -484,14 +484,6 @@ AC_OPTIONAL_FORMAT(oggvorbis, OGG_VORBIS, [AC_CHECK_HEADER(vorbis/codec.h,
   AC_CHECK_LIB(vorbisenc, vorbis_encode_init_vbr, OGG_VORBIS_LIBS="-lvorbisenc $OGG_VORBIS_LIBS", using_oggvorbis=no, $OGG_VORBIS_LIBS)],
   using_oggvorbis=no)])
 
-# Check for Opus
-AC_OPTIONAL_FORMAT(opus, OPUS,
-  [PKG_CHECK_MODULES(OPUS, [opusfile], [], using_opus=no)],
-  using_opus=no)
-if test "$GCC" = "yes"; then
-  OPUS_CFLAGS="$OPUS_CFLAGS -Wno-long-long"
-fi
-
 
 # Check for FLAC libraries
 #  Note passing in OGG_VORBIS_LIBS.  That is because FLAC has optional

--- a/configure.ac
+++ b/configure.ac
@@ -734,7 +734,6 @@ if test "x$using_twolame" = "xyes"; then
 echo " dlopen twolame............$enable_dl_twolame"
 fi
 echo "oggvorbis..................$using_oggvorbis"
-echo "opus.......................$using_opus"
 echo "sndfile....................$using_sndfile"
 if test "x$using_sndfile" = "xyes"; then
 echo " dlopen sndfile............$enable_dl_sndfile"

--- a/src/optional-fmts.am
+++ b/src/optional-fmts.am
@@ -135,22 +135,6 @@ else
 endif
 endif
 
-if HAVE_OPUS
-if STATIC_OPUS
-  libsox_la_SOURCES += opus.c
-  libsox_la_CFLAGS += @OPUS_CFLAGS@
-if STATIC_LIBSOX_ONLY
-  sox_LDADD += @OPUS_LIBS@
-else
-  libsox_la_LIBADD += @OPUS_LIBS@
-endif
-else
-  libsox_fmt_opus_la_SOURCES = opus.c
-  libsox_fmt_opus_la_CFLAGS = @OPUS_CFLAGS@
-  libsox_fmt_opus_la_LIBADD = libsox.la @OPUS_LIBS@
-  pkglib_LTLIBRARIES += libsox_fmt_opus.la
-endif
-endif
 
 if HAVE_OSS
 if STATIC_OSS


### PR DESCRIPTION
Hi Mansr, trying to compile sox for macOS Sierra I had this error:
./configure: line 15062: syntax error near unexpected token `OPUS,
I tried many things but I solved removing totally opus; I didn't try to spend a lot of time trying to look for a more elegant solution due to the very low use of this kind of audio codec